### PR TITLE
Adding watchOS 2.0

### DIFF
--- a/FDKeychain.podspec
+++ b/FDKeychain.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = '2.0'
   
   s.frameworks = "Foundation", "Security"
   s.requires_arc = true


### PR DESCRIPTION
In order to use this awesome pod in watchOS 2 the pod spec has to be extended to include watchOS target